### PR TITLE
Fix README typos and gulp syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Quick Start
 var styledown = require('gulp-styledown');
 
 gulp.src('/path/to/styledown/*.md')
-.pipe(styldown({
+.pipe(styledown({
   config: '/path/to/config.md'
   filename: 'output.html'
 }))
-.pipe.dest('paht/to/');
+.pipe(gulp.dest('/path/to/'));
 ```
 
 Options


### PR DESCRIPTION
The README example does not work as is. 
I updated the example to use `.pipe(gulp.dest(''));` and fixed a few typos.

The task runs now. 
